### PR TITLE
Fix undefined variable notices

### DIFF
--- a/extend/application/models/fcPayOneOrder.php
+++ b/extend/application/models/fcPayOneOrder.php
@@ -672,14 +672,22 @@ class fcPayOneOrder extends fcPayOneOrder_parent
         $oUtilsDate = $this->_oFcpoHelper->fcpoGetUtilsDate();
 
         //V #M525 orderdate must be the same as it was
-        if (!$this->oxorder__oxorderdate->value) {
+        if (!$this->oxorder__oxorderdate || !$this->oxorder__oxorderdate->value) {
             $this->oxorder__oxorderdate = new oxField(date('Y-m-d H:i:s', $oUtilsDate->getTime()), oxField::T_RAW);
         } else {
-            $this->oxorder__oxorderdate = new oxField($oUtilsDate->formatDBDate($this->oxorder__oxorderdate->value, true));
+            $this->oxorder__oxorderdate = new oxField(
+                $this->oxorder__oxorderdate ? $this->oxorder__oxorderdate->value : null,
+                true
+            );
         }
 
         $this->oxorder__oxshopid = new oxField($oConfig->getShopId(), oxField::T_RAW);
-        $this->oxorder__oxsenddate = new oxField($oUtilsDate->formatDBDate($this->oxorder__oxsenddate->value, true));
+        $this->oxorder__oxsenddate = new oxField(
+            $oUtilsDate->formatDBDate(
+                $this->oxorder__oxsenddate ? $this->oxorder__oxsenddate->value : null,
+                true
+            )
+        );
 
         if (( $blInsert = parent::_insert())) {
             // setting order number


### PR DESCRIPTION
Check if parameter exist before using is as an object. Otherwise a notice appears.

Similar as https://github.com/OXID-eSales/oxideshop_ce/commit/55aadda4f5d6e62a190b8178f05b5961642d6e23