### PR TITLE
Remove copy pasted code in admin order blocks

### DIFF
--- a/out/blocks/fcpo_admin_order_list_colgroup.tpl
+++ b/out/blocks/fcpo_admin_order_list_colgroup.tpl
@@ -1,9 +1,3 @@
-<col width="25%">
-<col width="25%">
 <col width="10%">
-<col width="11%">
-<col width="11%">
-<!-- FCPAYONE BEGIN -->
-<col width="10%">
-<!-- FCPAYONE END -->
-<col width="4%">
+
+[{$smarty.block.parent}]

--- a/out/blocks/fcpo_admin_order_list_filter.tpl
+++ b/out/blocks/fcpo_admin_order_list_filter.tpl
@@ -1,68 +1,9 @@
 <td valign="top" class="listfilter first" height="20">
-    <div class="r1"><div class="b1">
-    <select name="folder" class="folderselect" onChange="document.search.submit();">
-        <option value="-1" style="color: #000000;">[{oxmultilang ident="ORDER_LIST_FOLDER_ALL"}]</option>
-        [{foreach from=$afolder key=field item=color}]
-        <option value="[{$field}]" [{if $folder == $field}]SELECTED[{/if}] style="color: [{$color}];">[{oxmultilang ident=$field noerror=true}]</option>
-        [{/foreach}]
-    </select>
-    <input autocomplete="off" class="listedit" type="text" size="15" maxlength="128" name="where[oxorder][oxorderdate]" value="[{$where.oxorder.oxorderdate|oxformdate}]" [{include file="help.tpl" helpid=order_date}]>
-    </div></div>
+    <div class="r1">
+        <div class="b1">
+            <input autocomplete="off" class="listedit" type="text" size="7" maxlength="128" name="where[oxorder][fcporefnr]" value="[{$where.oxorder.fcporefnr}]">
+        </div>
+    </div>
 </td>
-<td valign="top" class="listfilter" height="20">
-    <div class="r1"><div class="b1">
-    <select name="addsearchfld" class="folderselect" >
-        <option value="-1" style="color: #000000;">[{oxmultilang ident="ORDER_LIST_PAID"}]</option>
-        [{foreach from=$asearch key=table item=desc}]
-        [{assign var="ident" value=ORDER_SEARCH_FIELD_$desc}]
-        [{assign var="ident" value=$ident|oxupper}]
-        <option value="[{$table}]" [{if $addsearchfld == $table}]SELECTED[{/if}]>[{oxmultilang|oxtruncate:20:"..":true ident=$ident}]</option>
-        [{/foreach}]
-    </select>
-    <input autocomplete="off" class="listedit" type="text" size="15" maxlength="128" name="addsearch" value="[{$addsearch}]">
-    </div></div>
-</td>
-<td valign="top" class="listfilter" height="20">
-    <div class="r1"><div class="b1">
-    <input autocomplete="off" class="listedit" type="text" size="7" maxlength="128" name="where[oxorder][oxordernr]" value="[{$where.oxorder.oxordernr}]">
-    </div></div>
-</td>
-<td valign="top" class="listfilter" height="20">
-    <div class="r1"><div class="b1">
-    <input autocomplete="off" class="listedit" type="text" size="25" maxlength="128" name="where[oxorder][oxbillfname]" value="[{$where.oxorder.oxbillfname}]">
-    </div></div>
-</td>
-<td valign="top" class="listfilter" height="20">
-    <div class="r1"><div class="b1">
-	<input autocomplete="off" class="listedit" type="text" size="25" maxlength="128" name="where[oxorder][oxbilllname]" value="[{$where.oxorder.oxbilllname}]">
-    </div></div>
-</td>
-<td valign="top" class="listfilter" height="20" colspan="2" nowrap>
-    <div class="r1"><div class="b1">
-    <div class="find"><input class="listedit" type="submit" name="submitit" value="[{oxmultilang ident="GENERAL_SEARCH"}]"></div>
-    <!-- FCPAYONE BEGIN -->
-    <input autocomplete="off" class="listedit" type="text" size="7" maxlength="128" name="where[oxorder][fcporefnr]" value="[{$where.oxorder.fcporefnr}]">
-    <script type="text/javascript">
-    <!--
-    function FCPOdeleteThisOrder(sID)
-    {
-        var blCheck = confirm("[{oxmultilang ident="FCPO_ORDER_LIST_YOUWANTTODELETE"}]");
-        if( blCheck == true ) {
-            var oTransfer = top.basefrm.edit.document.getElementById( "transfer" );
-            oTransfer.oxid.value = '-1';
-            oTransfer.cl.value = top.oxid.admin.getClass( -1 );
 
-            //forcing edit frame to reload after submit
-            top.forceReloadingEditFrame();
-
-            var oSearch = top.basefrm.list.document.getElementById( "search" );
-            oSearch.oxid.value = sID;
-            oSearch.fnc.value = 'deleteentry';
-            oSearch.submit();
-        }
-    }
-    //-->
-    </script>
-    <!-- FCPAYONE END -->
-    </div></div>
-</td>
+[{$smarty.block.parent}]

--- a/out/blocks/fcpo_admin_order_list_item.tpl
+++ b/out/blocks/fcpo_admin_order_list_item.tpl
@@ -1,28 +1,16 @@
-[{if $listitem->oxorder__oxstorno->value == 1}]
-    [{assign var="listclass" value=listitem3}]
-    [{else}]
-    [{if $listitem->blacklist == 1}]
-    [{assign var="listclass" value=listitem3}]
-    [{else}]
-    [{assign var="listclass" value=listitem$blWhite}]
-    [{/if}]
-    [{/if}]
-[{if $listitem->getId() == $oxid}]
-    [{assign var="listclass" value=listitem4}]
-    [{/if}]
-<td valign="top" class="[{$listclass}] order_time" height="15"><div class="listitemfloating">&nbsp;<a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__oxorderdate|oxformdate:'datetime':true}]</a></div></td>
-<td valign="top" class="[{$listclass}] payment_date" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__oxpaid|oxformdate}]</a></div></td>
-<td valign="top" class="[{$listclass}] order_no" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__oxordernr->value}]</a></div></td>
-<td valign="top" class="[{$listclass}] first_name" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__oxbillfname->value}]</a></div></td>
-<td valign="top" class="[{$listclass}] last_name" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__oxbilllname->value}]</a></div></td>
 <!-- FCPAYONE BEGIN -->
-<td valign="top" class="[{$listclass}]" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxorder__fcporefnr->value}]</a></div></td>
-<!-- FCPAYONE END -->
-<td class="[{$listclass}]">
-    [{if !$readonly}]
-    <!-- FCPAYONE BEGIN -->
-    <a href="Javascript:FCPOdeleteThisOrder('[{$listitem->oxorder__oxid->value}]');" class="delete" id="del.[{$_cnt}]" [{include file="help.tpl" helpid=item_delete}]></a>
-<!-- FCPAYONE END -->
-    <a href="Javascript:StornoThisArticle('[{$listitem->oxorder__oxid->value}]');" class="pause" id="pau.[{$_cnt}]" [{include file="help.tpl" helpid=item_storno}]></a>
-    [{/if}]</td>
+<td valign="top" class="[{$listclass}]" height="15">
+    <div class="listitemfloating">
+        <a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxorder__oxid->value}]');" class="[{$listclass}]">
+            [{$listitem->oxorder__fcporefnr->value}]
+        </a>
+    </div>
 </td>
+
+[{$smarty.block.parent}]
+
+<script type="text/javascript">
+    top.oxid.admin.getDeleteMessage = function () {
+        return '[{oxmultilang ident="FCPO_ORDER_LIST_YOUWANTTODELETE"}]';
+    }
+</script>

--- a/out/blocks/fcpo_admin_order_list_sorting.tpl
+++ b/out/blocks/fcpo_admin_order_list_sorting.tpl
@@ -1,8 +1,7 @@
-<td class="listheader first" height="15">&nbsp;<a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxorderdate', 'asc');document.search.submit();" class="listheader">[{oxmultilang ident="ORDER_LIST_ORDERTIME"}]</a></td>
-<td class="listheader" height="15"><a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxpaid', 'asc');document.search.submit();" class="listheader">[{oxmultilang ident="ORDER_LIST_PAID"}]</a></td>
-<td class="listheader" height="15"><a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxordernr', 'asc');document.search.submit();" class="listheader">[{oxmultilang ident="GENERAL_ORDERNUM"}]</a></td>
-<td class="listheader" height="15"><a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxbillfname', 'asc');document.search.submit();" class="listheader">[{oxmultilang ident="ORDER_LIST_CUSTOMERFNAME"}]</a></td>
-<td class="listheader" height="15"><a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxbilllname', 'asc');document.search.submit();" class="listheader">[{oxmultilang ident="ORDER_LIST_CUSTOMERLNAME"}]</a></td>
-<!-- FCPAYONE BEGIN -->
-<td class="listheader" height="15" colspan="2"><a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'fcporefnr', 'asc');document.search.submit();" class="listheader">PAYONE Ref.Nr.</a></td>
-<!-- FCPAYONE END -->
+<td class="listheader" height="15">
+    <a href="Javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'fcporefnr', 'asc');document.search.submit();" class="listheader">
+            PAYONE Ref.Nr.
+    </a>
+</td>
+
+[{$smarty.block.parent}]


### PR DESCRIPTION
Move columns to the beginning as it is easier to extend parent.

Having this is wrong because:
- Not calling parent will make break in a module chain
  (PayPal also extends same block)
- Duplicated coded increase maintenance costs as it must be synchronized
  with the changes in OXID eShop