### PR TITLE
Packagist depends on the correct usage of the identifiers from spdx

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["oxid", "modules", "eShop", "payment", "creditcard"],
   "homepage": "https://www.payone.com/",
   "license": [
-    "LGPL-3.0"
+    "LGPL-3.0-only"
   ],
   "extra": {
     "oxideshop": {


### PR DESCRIPTION
References:
https://spdx.org/licenses/
https://spdx.org/licenses/GPL-3.0-only.html
https://getcomposer.org/doc/04-schema.md#license