### PR TITLE
Improve test interoperability

### DIFF
--- a/tests/unit/fcPayOne/application/controllers/admin/fcpayone_mainTest.php
+++ b/tests/unit/fcPayOne/application/controllers/admin/fcpayone_mainTest.php
@@ -978,7 +978,7 @@ class Unit_fcPayOne_Application_Controllers_Admin_fcpayone_main extends OxidTest
     {
         $this->_fcpoTruncateTable('fcpoklarnastoreids');
         $sQuery = "
-            INSERT INTO `oxid`.`fcpoklarnastoreids` (`OXID`, `FCPO_STOREID`) VALUES ('1', 'samplestoreid')
+            INSERT INTO `fcpoklarnastoreids` (`OXID`, `FCPO_STOREID`) VALUES ('1', 'samplestoreid')
         ";
 
         oxDb::getDb()->Execute($sQuery);

--- a/tests/unit/fcPayOne/application/models/fcpoexportconfigTest.php
+++ b/tests/unit/fcPayOne/application/models/fcpoexportconfigTest.php
@@ -595,7 +595,7 @@ class Unit_fcPayOne_Application_Models_fcpoexportconfig extends OxidTestCase
     {
         $this->_fcpoTruncateTable('fcpoklarnastoreids');
         $sQuery = "
-            INSERT INTO `oxid`.`fcpoklarnastoreids` (`OXID`, `FCPO_STOREID`) VALUES ('1', 'samplestoreid')
+            INSERT INTO `fcpoklarnastoreids` (`OXID`, `FCPO_STOREID`) VALUES ('1', 'samplestoreid')
         ";
 
         oxDb::getDb()->Execute($sQuery);
@@ -611,7 +611,7 @@ class Unit_fcPayOne_Application_Models_fcpoexportconfig extends OxidTestCase
     {
         $this->_fcpoRemoveSamplePayment();
         $sQuery = "
-            INSERT INTO  `oxid`.`oxpayments` (
+            INSERT INTO  `oxpayments` (
                 `OXID` ,
                 `OXACTIVE` ,
                 `OXDESC` ,

--- a/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderTest.php
+++ b/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderTest.php
@@ -324,7 +324,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
 
-        $oMockUser = $this->getMock('oxBasket', array('save'));
+        $oMockUser = $this->getMock('oxUser', array('save'));
         $oMockUser->expects($this->any())->method('save')->will($this->returnValue(true));
 
         $oMockUtils = $this->getMock('oxUtils', array('logger'));
@@ -416,7 +416,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
 
-        $oMockUser = $this->getMock('oxBasket', array('save'));
+        $oMockUser = $this->getMock('oxUser', array('save'));
         $oMockUser->expects($this->any())->method('save')->will($this->returnValue(true));
 
         $oMockUtils = $this->getMock('oxUtils', array('logger'));
@@ -507,7 +507,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
 
-        $oMockUser = $this->getMock('oxBasket', array('save'));
+        $oMockUser = $this->getMock('oxUser', array('save'));
         $oMockUser->expects($this->any())->method('save')->will($this->returnValue(true));
 
         $oMockUtils = $this->getMock('oxUtils', array('logger'));
@@ -599,7 +599,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
 
-        $oMockUser = $this->getMock('oxBasket', array('save'));
+        $oMockUser = $this->getMock('oxUser', array('save'));
         $oMockUser->expects($this->any())->method('save')->will($this->returnValue(true));
 
         $oMockUtils = $this->getMock('oxUtils', array('logger'));
@@ -691,7 +691,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
         $oMockBasket->expects($this->any())->method('getTsProductId')->will($this->returnValue('someTsId'));
 
-        $oMockUser = $this->getMock('oxBasket', array('save'));
+        $oMockUser = $this->getMock('oxUser', array('save'));
         $oMockUser->expects($this->any())->method('save')->will($this->returnValue(true));
 
         $oMockUtils = $this->getMock('oxUtils', array('logger'));


### PR DESCRIPTION
- Use the right classes for mocked objects
- Do not provide a database name for test fixtures