### PR TITLE
Fix failing tests

### DIFF
--- a/tests/unit/fcPayOne/extend/application/controllers/fcPayOneOrderViewTest.php
+++ b/tests/unit/fcPayOne/extend/application/controllers/fcPayOneOrderViewTest.php
@@ -630,14 +630,28 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOneOrderView extends Oxi
         
         $oMockRequest = $this->getMock('fcporequest', array('sendRequestGenericPayment'));
         $oMockRequest->expects($this->any())->method('sendRequestGenericPayment')->will($this->returnValue($aMockOutput));
-        
-        $oHelper = $this->getMock('fcpohelper', array('fcpoGetSessionVariable', 'fcpoDeleteSessionVariable', 'getFactoryObject', 'fcpoGetSession'));
+
+        $oMockOrder = $this->getMock('oxOrder', array('load', 'fcpoGetIdByUserName'));
+        $oMockOrder->expects($this->any())->method('fcpoGetIdByUserName')->will($this->returnValue('someUserId'));
+        $oMockOrder->expects($this->any())->method('load')->will($this->returnValue(true));
+
+        $oHelper = $this->getMock('fcpohelper', array('fcpoGetSessionVariable', 'fcpoDeleteSessionVariable', 'fcpoGetSession'));
         $oHelper->expects($this->any())->method('fcpoGetSessionVariable')->will($this->returnValue('someValue'));
         $oHelper->expects($this->any())->method('fcpoDeleteSessionVariable')->will($this->returnValue(true));
-        $oHelper->expects($this->any())->method('getFactoryObject')->will($this->onConsecutiveCalls($oMockRequest, $oMockOxDeliverySet));
+        $oHelper->expects($this->any())->method('getFactoryObject')->will(
+            $this->onConsecutiveCalls(
+                $oMockRequest,
+                oxNew(oxubase::class),
+                $oMockOrder,
+                $oMockUserObject,
+                $oMockOrder,
+                $oMockOrder,
+                $oMockOrder,
+                $oMockOxDeliverySet
+            )
+        );
         $oHelper->expects($this->any())->method('fcpoGetSession')->will($this->returnValue($oMockSession));
-        
-        
+
         $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
         
         $mResponse = $mExpect = $this->invokeMethod($oTestObject, '_handlePayPalExpressCall');

--- a/tests/unit/fcPayOne/extend/application/controllers/fcPayonePaymentViewTest.php
+++ b/tests/unit/fcPayOne/extend/application/controllers/fcPayonePaymentViewTest.php
@@ -3547,6 +3547,8 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView extends O
      */
     public function test_fcpoGetPayolutionAgreementLink_Coverage()
     {
+        $sCompanyName = 'someCompany';
+
         $oMockLang = $this->getMock('oxLang', array(
             'getLanguageAbbr'
         ));
@@ -3561,9 +3563,9 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView extends O
         $oMockConfig
             ->expects($this->any())
             ->method('getConfigParam')
-            ->will($this->returnValue('someCompany'));
+            ->will($this->returnValue($sCompanyName));
 
-        $sExpect = 'https://payment.payolution.com/payolution-payment/infoport/dataprivacydeclaration?mId=&lang=someAbbr&territory=DE';
+        $sExpect = 'https://payment.payolution.com/payolution-payment/infoport/dataprivacydeclaration?mId=' . base64_encode($sCompanyName) . '&lang=someAbbr&territory=DE';
 
         $oTestObject = $this->getMock('fcPayOnePaymentView', array(
             'fcpoGetTargetCountry',


### PR DESCRIPTION
The following tests were fixed

- \Unit_fcPayOne_Extend_Application_Controllers_fcPayOneOrderView::test__handlePayPalExpressCall_Coverage
- \Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView::test_fcpoGetPayolutionAgreementLink_Coverage