### PR TITLE
BugFix: Enterprise edition module activation

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -225,9 +225,10 @@ $aModule = array(
     ),
 );
 
-if(class_exists('fcpohelper')) {
-    $sShopEdition = fcpohelper::fcpoGetStaticConfig()->getActiveShop()->oxshops__oxedition->value;
-    if($sShopEdition == 'EE') {
+if(class_exists('\OxidEsales\Facts\Facts')) {
+    $oFacts = new \OxidEsales\Facts\Facts();
+    $sShopEdition = $oFacts->getEdition();
+    if($sShopEdition == \OxidEsales\Facts\Edition\EditionSelector::ENTERPRISE) {
         $aModule['blocks'][] = array(
                 'template' => 'roles_bemain.tpl',
                 'block' => 'admin_roles_bemain_form',


### PR DESCRIPTION
Activation in the enterprise edition fails. Only second activation is successful, but duplicate template blocks were registered.

The fcpohelper class exists after first activation and modifies the metadata.php, so that the OXID eShop EE can not fully activate the module because the metadata.php was changed.