### PR TITLE
Define metadata version

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -19,6 +19,8 @@
  * @version   OXID eShop CE
  */
 
+$sMetadataVersion = '1.1';
+
 $aModule = array(
     'id'            => 'fcpayone',
     'title'         => 'PAYONE Payment f&uuml;r OXID eShop',


### PR DESCRIPTION
From the next minor release of OXID eShop CE metadata.php without metadata version is no longer valid. 