### PR TITLE
fixed failing unit tests

### DIFF
--- a/tests/unit/fcPayOne/application/controllers/fcpayoneiframeTest.php
+++ b/tests/unit/fcPayOne/application/controllers/fcpayoneiframeTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/** 
+ * PAYONE OXID Connector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PAYONE OXID Connector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with PAYONE OXID Connector.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link      http://www.payone.de
+ * @copyright (C) Payone GmbH
+ * @version   OXID eShop CE
+ */
+
+class Unit_fcPayOne_Application_Controllers_fcpayoneiframe extends OxidTestCase
+{
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    /**
+     * Set protected/private attribute value
+     *
+     * @param object &$object      Instantiated object that we will run method on.
+     * @param string $propertyName property that shall be set
+     * @param array  $value        value to be set
+     *
+     * @return mixed Method return.
+     */
+    public function invokeSetAttribute(&$object, $propertyName, $value)
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        $property->setValue($object, $value);
+    }
+
+    public function test_Render_Coverage()
+    {
+        $oTestObject = oxNew('fcpayoneiframe');
+
+        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
+        $oHelper->expects($this->any())->method('fcpoGetIntShopVersion')->will($this->returnValue(4800));
+
+        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
+
+        $sExpect = $sResult = $oTestObject->render();
+        $this->assertEquals($sExpect, $sResult);
+    }
+
+    public function test_Render_Coverage2()
+    {
+        $oTestObject = oxNew('fcpayoneiframe');
+
+        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
+        $oHelper->expects($this->any())->method('fcpoGetIntShopVersion')->will($this->returnValue(4600));
+
+        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
+
+        $sExpect = $sResult = $oTestObject->render();
+        $this->assertEquals($sExpect, $sResult);
+    }
+
+    public function test_getIframeHeight_Coverage()
+    {
+        $oTestObject = $this->getMock('fcpayoneiframe', array('getPaymentType'));
+        $oTestObject->expects($this->any())->method('getPaymentType')->will($this->returnValue('fcpocreditcard_iframe'));
+
+        $sResult = $oTestObject->getIframeHeight();
+
+        $this->assertNotEmpty($sResult);
+    }
+
+    public function test_getIframeText_Coverage()
+    {
+        $oTestObject = $this->getMock('fcpayoneiframe', array('getPaymentType'));
+        $oTestObject->expects($this->any())->method('getPaymentType')->will($this->returnValue('fcpocreditcard_iframe'));
+
+        $sResult = $oTestObject->getIframeText();
+
+        $this->assertFalse($sResult);
+    }
+
+    public function test_getIframeHeader_Coverage()
+    {
+        $oTestObject = $this->getMock('fcpayoneiframe', array('getPaymentType'));
+        $oTestObject->expects($this->any())->method('getPaymentType')->will($this->returnValue('fcpocreditcard_iframe'));
+
+        $sResult = $oTestObject->getIframeHeader();
+
+        $this->assertNotEmpty($sResult);
+    }
+
+    public function test_getIframeStyle_Coverage()
+    {
+        $oTestObject = $this->getMock('fcpayoneiframe', array('getPaymentType'));
+        $oTestObject->expects($this->any())->method('getPaymentType')->will($this->returnValue('fcpocreditcard_iframe'));
+
+        $sResult = $oTestObject->getIframeStyle();
+
+        $this->assertNotEmpty($sResult);
+    }
+
+    public function test_getIframeWidth_Coverage()
+    {
+        $oTestObject = $this->getMock('fcpayoneiframe', array('getPaymentType'));
+        $oTestObject->expects($this->any())->method('getPaymentType')->will($this->returnValue('fcpocreditcard_iframe'));
+
+        $sResult = $oTestObject->getIframeWidth();
+
+        $this->assertNotEmpty($sResult);
+    }
+
+    public function test_getFactoryObject_Coverage()
+    {
+        $oTestObject = oxNew('fcpayoneiframe');
+
+        $sResult = $oTestObject->getFactoryObject('oxOrder');
+
+        $this->assertInstanceOf('oxOrder', $sResult);
+    }
+
+
+
+
+
+
+}

--- a/tests/unit/fcPayOne/extend/application/controllers/fcPayonePaymentViewTest.php
+++ b/tests/unit/fcPayOne/extend/application/controllers/fcPayonePaymentViewTest.php
@@ -934,6 +934,7 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView extends O
                 'getPostFinanceCard',
                 'getIdeal',
                 'getP24',
+                'getBancontact',
                 '_fcpoGetOnlinePaymentData',
             )
         );
@@ -945,9 +946,10 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView extends O
         $oTestObject->expects($this->any())->method('getPostFinanceCard')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('getIdeal')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('getP24')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('getBancontact')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('_fcpoGetOnlinePaymentData')->will($this->returnValue('someValue'));
 
-        $aExpect = array('someValue', 'someValue', 'someValue', 'someValue', 'someValue', 'someValue', 'someValue');
+        $aExpect = array('someValue', 'someValue', 'someValue', 'someValue', 'someValue', 'someValue', 'someValue', 'someValue');
         $aResponse = $oTestObject->fcpoGetOnlinePaymentMetaData();
 
         $this->assertEquals($aExpect, $aResponse);
@@ -967,6 +969,24 @@ class Unit_fcPayOne_Extend_Application_Controllers_fcPayOnePaymentView extends O
         $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
 
         $this->assertEquals('flow', $oTestObject->fcpoGetActiveThemePath());
+    }
+
+    /**
+     * Testing fcpoGetActiveThemePath for coverage
+     */
+    public function test_fcpoValidatePayolutionBillHasTelephone_Coverage() {
+        $oTestObject = $this->getMock('fcPayOnePaymentView', array('_fcpoValidatePayolutionBillHasTelephone', 'fcpoGetUserValue'));
+        $oTestObject->expects($this->any())->method('_fcpoValidatePayolutionBillHasTelephone')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('fcpoGetUserValue')->will($this->returnValue(false));
+
+        $oMockViewConfig = $this->getMock('oxViewConfig', array('fcpoGetActiveThemePath'));
+        $oMockViewConfig->expects($this->any())->method('fcpoGetActiveThemePath')->will($this->returnValue('flow'));
+
+        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
+        $oHelper->expects($this->any())->method('getFactoryObject')->will($this->returnValue($oMockViewConfig));
+        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
+
+        $this->assertTrue($oTestObject->_fcpoValidatePayolutionBillHasTelephone());
     }
 
 

--- a/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderTest.php
+++ b/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderTest.php
@@ -406,6 +406,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
      */
     public function test_finalizeOrder_IsPayone() 
     {
+        //TODO: reduce
         $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
         $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
 
@@ -576,8 +577,6 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oHelper->expects($this->any())->method('fcpoDeleteSessionVariable')->will($this->returnValue(true));
         $oHelper->expects($this->any())->method('fcpoGetUtils')->will($this->returnValue($oMockUtils));
 
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
-
         $this->assertEquals(1, $oTestObject->finalizeOrder($oMockBasket, $oMockUser, false));
     }
 
@@ -667,8 +666,6 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oHelper->expects($this->any())->method('fcpoGetSessionVariable')->will($this->returnValue('someSessionValue'));
         $oHelper->expects($this->any())->method('fcpoDeleteSessionVariable')->will($this->returnValue(true));
 
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
-
         $this->assertEquals(false, $oTestObject->finalizeOrder($oMockBasket, $oMockUser, false));
     }
 
@@ -755,13 +752,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oTestObject->expects($this->any())->method('_fcpoMarkVouchers')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('_fcpoFinishOrder')->will($this->returnValue(true));
 
-        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
-        $oHelper->expects($this->any())->method('fcpoGetSessionVariable')->will($this->returnValue('someSessionValue'));
-        $oHelper->expects($this->any())->method('fcpoDeleteSessionVariable')->will($this->returnValue(true));
-
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
-
-        $this->assertEquals(1, $oTestObject->finalizeOrder($oMockBasket, $oMockUser, false));
+        $this->assertEquals(1, $oTestObject->finalizeOrder($oMockBasket, $oMockUser, true));
     }
 
     /**
@@ -2187,9 +2178,6 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockDb = $this->getMock('oxDb', array('Execute'));
         $oMockDb->expects($this->any())->method('Execute')->will($this->returnValue(true));
 
-        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
-        $oHelper->expects($this->any())->method('fcpoSetSessionVariable')->will($this->returnValue(true));
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
         $this->invokeSetAttribute($oTestObject, '_oFcpoDb', $oMockDb);
 
         $aMockResponse = array('add_paydata[instruction_notes]' => 'someValue', 'txid' => 'someTxid', 'add_paydata[clearing_reference]' => 'someReference');
@@ -2213,11 +2201,6 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrder extends OxidTestCase
         $oMockDb = $this->getMock('oxDb', array('Execute'));
         $oMockDb->expects($this->any())->method('Execute')->will($this->returnValue(true));
 
-        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
-        $oHelper->expects($this->any())->method('fcpoSetSessionVariable')->will($this->returnValue(true));
-        $oHelper->expects($this->any())->method('fcpoGetSessionVariable')->will($this->returnValue('someWorkerId'));
-        
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
         $this->invokeSetAttribute($oTestObject, '_oFcpoDb', $oMockDb);
 
         $aMockResponse = array('add_paydata[instruction_notes]' => 'someValue', 'txid' => 'someTxid', 'add_paydata[clearing_reference]' => 'someReference');

--- a/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderarticleTest.php
+++ b/tests/unit/fcPayOne/extend/application/models/fcPayOneOrderarticleTest.php
@@ -62,7 +62,7 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrderarticleTest extends O
     /**
      * Testing save method for calling parent save
      */
-    public function test_save_Parent() 
+    public function test_save_Parent()
     {
         $oMockOrder = $this->getMock('oxOrder', array('isPayOnePaymentType'));
         $oMockOrder->expects($this->any())->method('isPayOnePaymentType')->will($this->returnValue(false));
@@ -106,22 +106,28 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrderarticleTest extends O
         $oMockSession = $this->getMock('oxSession', array('getBasket'));
         $oMockSession->expects($this->any())->method('getBasket')->will($this->returnValue($oMockBasket));
 
-        $oTestObject = $this->getMock('fcPayOneOrderarticle', array('_fcpoGetBefore'));
-        $oTestObject->expects($this->any())->method('_fcpoGetBefore')->will($this->returnValue(false));
-        $oTestObject->expects($this->any())->method('_setOrderFiles')->will($this->returnValue(true));
-        $oTestObject->expects($this->any())->method('updateArticleStock')->will($this->returnValue(true));
-        $oTestObject->expects($this->any())->method('setIsNewOrderItem')->will($this->returnValue(true));
-        
         $oMockConfig = $this->getMock('oxConfig', array('getConfigParam'));
         $oMockConfig->expects($this->any())->method('getConfigParam')->will($this->returnValue(true));
 
-        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
-        $oHelper->expects($this->any())->method('fcpoGetConfig')->will($this->returnValue($oMockConfig));
-        $oHelper->expects($this->any())->method('fcpoGetRequestParameter')->will($this->returnValue(true));
-        $oHelper->expects($this->any())->method('fcpoGetIntShopVersion')->will($this->returnValue(4800));
-        $oHelper->expects($this->any())->method('fcpoGetSession')->will($this->returnValue($oMockSession));
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
-        $mResponse = $mExpect = $oTestObject->save($oMockOrder, true);
+        $oTestObject = $this->getMock('fcPayOneOrderarticle',
+            array('_fcpoGetBefore',
+                'getOrder',
+                '_setOrderFiles',
+                'updateArticleStock',
+                'setIsNewOrderItem',
+                'fcpoGetConfig',
+                'getSession'
+            )
+        );
+        $oTestObject->expects($this->any())->method('getOrder')->will($this->returnValue($oMockOrder));
+        $oTestObject->expects($this->any())->method('_fcpoGetBefore')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('_setOrderFiles')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('updateArticleStock')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('setIsNewOrderItem')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('fcpoGetConfig')->will($this->returnValue($oMockConfig));
+        $oTestObject->expects($this->any())->method('getSessions')->will($this->returnValue($oMockSession));
+
+        $mResponse = $mExpect = $oTestObject->save();
 
         $this->assertEquals($mResponse, $mExpect);
     }
@@ -141,23 +147,69 @@ class Unit_fcPayOne_Extend_Application_Models_fcPayOneOrderarticleTest extends O
         $oMockSession = $this->getMock('oxSession', array('getBasket'));
         $oMockSession->expects($this->any())->method('getBasket')->will($this->returnValue($oMockBasket));
 
-        $oTestObject = $this->getMock('fcPayOneOrderarticle', array('_fcpoGetBefore'));
+        $oMockConfig = $this->getMock('oxConfig', array('getConfigParam'));
+        $oMockConfig->expects($this->any())->method('getConfigParam')->will($this->onConsecutiveCalls(true, true, false, true, true));
+
+        $oTestObject = $this->getMock('fcPayOneOrderarticle',
+            array('_fcpoGetBefore',
+                'getOrder',
+                '_setOrderFiles',
+                'updateArticleStock',
+                'setIsNewOrderItem',
+                'fcpoGetConfig',
+                'getSession'
+            )
+        );
+
+        $oTestObject->expects($this->any())->method('getOrder')->will($this->returnValue($oMockOrder));
+        $oTestObject->expects($this->any())->method('_fcpoGetBefore')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('_setOrderFiles')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('updateArticleStock')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('setIsNewOrderItem')->will($this->returnValue(true));
+        $oTestObject->expects($this->any())->method('fcpoGetConfig')->will($this->returnValue($oMockConfig));
+        $oTestObject->expects($this->any())->method('getSessions')->will($this->returnValue($oMockSession));
+
+        $mResponse = $mExpect = $oTestObject->save();
+
+        $this->assertEquals($mResponse, $mExpect);
+    }
+
+    /**
+     * Testing save method for coverage
+     */
+    public function test_save_Coverage_3()
+    {
+        $oMockOrder = $this->getMock('oxOrder', array('isPayOnePaymentType'));
+        $oMockOrder->expects($this->any())->method('isPayOnePaymentType')->will($this->returnValue(true));
+
+        $oMockBasket = $this->getMock('oxBasket', array('getPaymentId'));
+        $oMockBasket->expects($this->any())->method('getPaymentId')->will($this->returnValue('somePaymentId'));
+
+        $oMockSession = $this->getMock('oxSession', array('getBasket'));
+        $oMockSession->expects($this->any())->method('getBasket')->will($this->returnValue($oMockBasket));
+
+        $oMockConfig = $this->getMock('oxConfig', array('getConfigParam'));
+        $oMockConfig->expects($this->any())->method('getConfigParam')->will($this->returnValue(true));
+
+        $oTestObject = $this->getMock('fcPayOneOrderarticle',
+            array('_fcpoGetBefore',
+                'getOrder',
+                '_setOrderFiles',
+                'updateArticleStock',
+                'setIsNewOrderItem',
+                'fcpoGetConfig',
+                'getSession'
+            )
+        );
+        $oTestObject->expects($this->any())->method('getOrder')->will($this->returnValue($oMockOrder));
         $oTestObject->expects($this->any())->method('_fcpoGetBefore')->will($this->returnValue(false));
         $oTestObject->expects($this->any())->method('_setOrderFiles')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('updateArticleStock')->will($this->returnValue(true));
         $oTestObject->expects($this->any())->method('setIsNewOrderItem')->will($this->returnValue(true));
-        
-        $oMockConfig = $this->getMock('oxConfig', array('getConfigParam'));
-        $oMockConfig->expects($this->any())->method('getConfigParam')->will($this->onConsecutiveCalls(true, true, false, true, true));
-        
-        $oHelper = $this->getMockBuilder('fcpohelper')->disableOriginalConstructor()->getMock();
-        $oHelper->expects($this->any())->method('fcpoGetConfig')->will($this->returnValue($oMockConfig));
-        $oHelper->expects($this->any())->method('fcpoGetRequestParameter')->will($this->returnValue(true));
-        $oHelper->expects($this->any())->method('fcpoGetIntShopVersion')->will($this->returnValue(4800));
-        $oHelper->expects($this->any())->method('fcpoGetSession')->will($this->returnValue($oMockSession));
-        $this->invokeSetAttribute($oTestObject, '_oFcpoHelper', $oHelper);
+        $oTestObject->expects($this->any())->method('fcpoGetConfig')->will($this->returnValue($oMockConfig));
+        $oTestObject->expects($this->any())->method('getSessions')->will($this->returnValue($oMockSession));
 
-        $mResponse = $mExpect = $oTestObject->save($oMockOrder, true);
+        $mResponse = $mExpect = $oTestObject->save();
 
         $this->assertEquals($mResponse, $mExpect);
     }


### PR DESCRIPTION
fixed finalize Order IsPayone_RecalcOrderHasOrderState & IsPayone_OrderExists

fixed finalize Order IsPayone_RecalcOrderHasOrderState & IsPayone_OrderExists #2

fixed fcpoHandleAuthorizationApproved Barzahlen & Payolution

fixed order article save test

reactivated parent test

added payone iframe test

increased coverage