### PR TITLE
Fix warning with PHP 7.2

### DIFF
--- a/core/fcpayone_events.php
+++ b/core/fcpayone_events.php
@@ -584,7 +584,7 @@ class fcpayone_events
     {
         $aColumns = oxDb::getDb()->getAll("SHOW COLUMNS FROM {$sTableName} LIKE '{$sColumnName}'");
 
-        if (!$aColumns || count($aColumns == 0)) {
+        if (!$aColumns || count($aColumns) === 0) {
             try {
                 oxDb::getDb()->Execute($sQuery);
             } catch (Exception $e) {


### PR DESCRIPTION
The warning which was occurring while running tests with PHP 7.2 was:
`Warning: count(): Parameter must be an array or an object that implements Countable in source/modules/fc/fcpayone/core/fcpayone_events.php on line 587`

This warning also caused to break OXID eShop session tests.