### PR TITLE
use translated error messages for credit card (hosted iframe)

### DIFF
--- a/application/views/frontend/tpl/fcpo_payment_creditcard_script.tpl
+++ b/application/views/frontend/tpl/fcpo_payment_creditcard_script.tpl
@@ -1,3 +1,9 @@
+[{foreach from=$oxcmp_lang item=_lng}]
+    [{if $_lng->selected}]
+        [{assign var="activeLng" value=$_lng->abbr}]
+    [{/if}]
+[{/foreach}]
+
 <script>
     var request, config;
     config = {
@@ -76,13 +82,13 @@
         },
         [{if $oView->getConfigParam('blFCPOCCErrorsActive')}]
             error: "errorOutput", // area to display error-messages (optional)
-            [{if $oView->getConfigParam('sFCPOCCErrorsLang') == "de"}]
-                language: Payone.ClientApi.Language.de // Language to display error-messages
-            [{else}]
-                language: Payone.ClientApi.Language.en
-            [{/if}]
+            language: Payone.ClientApi.Language.en
         [{/if}]
     };
+    [{* use the translation available for the current shop language, if available *}]
+    if(Payone.ClientApi.Language.hasOwnProperty('[{$activeLng}]')) {
+        config.language = Payone.ClientApi.Language['[{$activeLng}]'];
+    }
     [{capture name="fcpoCCIframes"}]
         [{foreach from=$oViewConf->fcpoGetIframeMappings() item='oMapping'}]
             [{assign var='sLangId' value=$oMapping->sLangId}]


### PR DESCRIPTION
This is strictly better than the current option, which just uses the language selected in the shop backend. However, it only works with the languages defined on the `Payone.ClientApi.Language` object, it's not straightforward for the user to set translations for languages that are not provided there.

If you want to move forward with this PR, I can remove the language selection for the error message in the backend, as it's not needed any longer. Please let me know and I'll update the PR.