### PR TITLE
Remove deprecated mapTestClassNameToCoveredClassName

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -6,7 +6,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"


### PR DESCRIPTION
This option should be removed in order the tests to pass