### PR TITLE
OXDEV-3672 Fix OXTIMESTAMP issue with MySQL 5.5

### DIFF
--- a/core/fcpayone_events.php
+++ b/core/fcpayone_events.php
@@ -52,7 +52,7 @@ class fcpayone_events
           FCPO_REFNR int(11) NOT NULL AUTO_INCREMENT,
           FCPO_TXID varchar(32) NOT NULL DEFAULT '',
           FCPO_REFPREFIX varchar(32) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (FCPO_REFNR, FCPO_REFPREFIX)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcporequestlog = "
@@ -66,7 +66,7 @@ class fcpayone_events
           FCPO_RESPONSE text NOT NULL,
           FCPO_PORTALID varchar(32) NOT NULL DEFAULT '',
           FCPO_AID varchar(32) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (OXID)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpotransactionstatus = "
@@ -115,7 +115,7 @@ class fcpayone_events
           FCPO_CUSTOMERID int(11) NOT NULL DEFAULT '0',
           FCPO_BALANCE double NOT NULL DEFAULT '0',
           FCPO_RECEIVABLE double NOT NULL DEFAULT '0',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (OXID)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpopayment2country = "
@@ -124,7 +124,7 @@ class fcpayone_events
           FCPO_PAYMENTID char(8) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT '',
           FCPO_COUNTRYID char(32) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT '',
           FCPO_TYPE char(8) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (`OXID`),
           KEY `FCPO_PAYMENTID` (`FCPO_PAYMENTID`),
           KEY `FCPO_COUNTRYID` (`FCPO_COUNTRYID`),
@@ -136,7 +136,7 @@ class fcpayone_events
                 FCPO_PAYONESTATUS VARCHAR(32) CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
                 FCPO_URL VARCHAR(255) CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
                 FCPO_TIMEOUT DOUBLE NOT NULL DEFAULT '0' ,
-                OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+                OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
                 PRIMARY KEY (`OXID`)
         );";
     public static $sQueryTableFcpoStatusMapping = "
@@ -145,7 +145,7 @@ class fcpayone_events
                 FCPO_PAYMENTID CHAR(32) CHARSET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT '' ,
                 FCPO_PAYONESTATUS VARCHAR(32) CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
                 FCPO_FOLDER VARCHAR(32) CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
-                OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+                OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
                 PRIMARY KEY (`OXID`)
         );";
     public static $sQueryTableFcpoErrorMapping = "
@@ -155,7 +155,7 @@ class fcpayone_events
                 FCPO_LANG_ID VARCHAR(32) CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
                 FCPO_MAPPED_MESSAGE TEXT CHARSET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '' ,
                 FCPO_ERROR_TYPE VARCHAR(32) CHARSET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT '' ,
-                OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+                OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
                 PRIMARY KEY (`OXID`),
                 KEY `FCPO_ERROR_TYPE` (`FCPO_ERROR_TYPE`)
         );";
@@ -163,14 +163,14 @@ class fcpayone_events
         CREATE TABLE fcpoklarnastoreids (
           OXID int(11) NOT NULL AUTO_INCREMENT,
           FCPO_STOREID varchar(32) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (OXID)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpoPdfMandates = "
         CREATE TABLE fcpopdfmandates (
           OXORDERID char(32) COLLATE latin1_general_ci NOT NULL,
           FCPO_FILENAME varchar(32) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          `OXTIMESTAMP` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',          
           PRIMARY KEY (OXORDERID)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpoklarnacampaigns = "
@@ -178,7 +178,7 @@ class fcpayone_events
           OXID int(11) NOT NULL AUTO_INCREMENT,
           FCPO_CAMPAIGN_CODE varchar(32) NOT NULL DEFAULT '',
           FCPO_CAMPAIGN_TITLE varchar(128) NOT NULL DEFAULT '',
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (OXID)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpopaypalexpresslogos = "
@@ -188,14 +188,14 @@ class fcpayone_events
             FCPO_LANGID INT( 11 ) NOT NULL ,
             FCPO_LOGO VARCHAR( 255 ) NOT NULL ,
             FCPO_DEFAULT TINYINT( 1 ) NOT NULL DEFAULT '0',
-            OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+            OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
             PRIMARY KEY (OXID)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;";
     public static $sQueryTableFcpocheckedaddresses = "
         CREATE TABLE fcpocheckedaddresses (
           fcpo_address_hash CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           fcpo_checkdate TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (fcpo_address_hash)
         ) ENGINE=INNODB DEFAULT CHARSET=latin1 COLLATE=latin1_general_ci;";
 
@@ -261,7 +261,7 @@ class fcpayone_events
           `tx_limit_prepayment_max` double DEFAULT NULL,
           `txLimitPrepaymentMin` double DEFAULT NULL,
           `valid_payment_firstdays` int(11) DEFAULT NULL,
-          OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
+          OXTIMESTAMP CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
           PRIMARY KEY (OXID)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
     ";
@@ -352,7 +352,7 @@ class fcpayone_events
     public static $sQueryChangeRefNrToVarchar = "ALTER TABLE oxorder CHANGE FCPOREFNR FCPOREFNR VARCHAR( 32 ) NOT NULL DEFAULT '0'";
     public static $sQueryAlterFcpoTransactionStatusChangeToChar = "ALTER TABLE fcpotransactionstatus CHANGE OXID OXID CHAR(32) NOT NULL;";
     public static $sQueryAlterFcpoTransactionForwardingChangeToChar = "ALTER TABLE fcpostatusforwarding CHANGE OXID OXID CHAR(32) NOT NULL;";
-    public static $sQueryChangeMandateTimestamp = "ALTER TABLE fcpopdfmandates CHANGE OXTIMESTAMP OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp';";
+    public static $sQueryChangeMandateTimestamp = "ALTER TABLE fcpopdfmandates CHANGE OXTIMESTAMP OXTIMESTAMP DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP";
     public static $aPaymentMethods = array(
         'fcpoinvoice' => 'Rechnung',
         'fcpopayadvance' => 'Vorauskasse',
@@ -406,7 +406,7 @@ class fcpayone_events
         self::clearTmp();
         $sMessage .= "Tmp geleert...<br>";
         $sMessage .= "Installation erfolgreich!<br>";
-        // self::$_oFcpoHelper->fcpoGetUtilsView()->addErrorToDisplay($sMessage, false, true);
+        //self::$_oFcpoHelper->fcpoGetUtilsView()->addErrorToDisplay($sMessage, false, true);
     }
 
     /**
@@ -581,7 +581,7 @@ class fcpayone_events
         self::changeColumnTypeIfWrong('oxorder', 'FCPOREFNR', 'varchar(32)', self::$sQueryChangeRefNrToVarchar);
         self::changeColumnTypeIfWrong('fcpotransactionstatus', 'OXID', 'int(11)', self::$sQueryAlterFcpoTransactionStatusChangeToChar);
         self::changeColumnTypeIfWrong('fcpostatusforwarding', 'OXID', 'int(11)', self::$sQueryAlterFcpoTransactionForwardingChangeToChar);
-        self::changeColumnTypeIfWrong('fcpopdfmandates', 'OXTIMESTAMP', 'TIMESTAMP', self::$sQueryChangeMandateTimestamp);
+        self::changeColumnTypeIfWrong('fcpopdfmandates', 'OXTIMESTAMP', 'DATETIME', self::$sQueryChangeMandateTimestamp);
 
         self::dropIndexIfExists('fcporefnr', 'FCPO_REFNR');
 
@@ -678,7 +678,7 @@ class fcpayone_events
             WHERE FIELD = '{$sColumnName}' 
             AND TYPE = '{$sExpectedType}'
         ";
-        if (!oxDb::getDb()->getOne($sCheckQuery)) {
+        if (oxDb::getDb()->getOne($sCheckQuery)) {
             oxDb::getDb()->Execute($sQuery);
             return true;
         }


### PR DESCRIPTION
Latest changes in dev-master in core/fcpayone_events.php for OXTIMESTAMP lead to problems when running OXID compilation tests: (PHP 7.2, MySQL 5.5), see below. As tests in travis are green maybe a stupid question: is it possible, that in travis module's onActivate is never called? This PR reverts latest changes in OXTIMESTAMP and fixes the compilation builds on OXID CI:

```
=========
running php version 7.2.31

============
Adding unit tests from /var/www/oxideshop/source/modules/fc/fcpayone/tests//unit/fcPayOne/application/controllers/*Test\.php

Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 1293 Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause in /var/www/oxideshop/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:41
Stack trace:
#0 /var/www/oxideshop/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php(41): PDO->exec('\n        CREATE...')
#1 /var/www/oxideshop/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1068): Doctrine\DBAL\Driver\PDOConnection->exec('\n        CREATE...')
#2 /var/www/oxideshop/source/Core/Database/Adapter/Doctrine/Database.php(765): Doctrine\DBAL\Connection->executeUpdate('\n        CREATE...', Array, Array)
#3 /var/www/oxideshop/source/Core/Database/Adapter/Doctrine/Database.php(564): OxidEsales\EshopCommunity\Core\Database\Adapter\Doctrine\Database->executeUpdate('\n        CREATE...', Array)
#4 /var/www/oxideshop/source/modules/fc/fcpayone/core/fcpayone_events.php(607): OxidEsales\EshopCommunity\Core\Database\Adap in /var/www/oxideshop/source/Core/Database/Adapter/Doctrine/Database.php on line 925

Warning: Cannot modify header information - headers already sent in /var/www/oxideshop/source/bootstrap.php on line 64

Warning: Cannot modify header information - headers already sent in /var/www/oxideshop/source/bootstrap.php on line 65

```