### PR TITLE
OXDEV-4082 Fix CURRENT_TIMESTAMP issue with MySQL 5.5

### DIFF
--- a/core/fcpayone_events.php
+++ b/core/fcpayone_events.php
@@ -192,7 +192,7 @@ class fcpayone_events
     public static $sQueryTableFcpocheckedaddresses = "
         CREATE TABLE fcpocheckedaddresses (
           fcpo_address_hash CHAR(32) COLLATE latin1_general_ci NOT NULL DEFAULT '',
-          fcpo_checkdate TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          fcpo_checkdate TIMESTAMP NOT NULL DEFAULT '2011-11-11 11:11:11',
           OXTIMESTAMP TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp',
           PRIMARY KEY (fcpo_address_hash)
         ) ENGINE=INNODB DEFAULT CHARSET=latin1 COLLATE=latin1_general_ci;";

--- a/lib/fcporequest.php
+++ b/lib/fcporequest.php
@@ -2940,7 +2940,7 @@ class fcpoRequest extends oxSuperCfg
     protected function _saveCheckedAddress($aResponse)
     {
         $sCheckHash = $this->_getAddressHash($aResponse);
-        $sQuery = "REPLACE INTO fcpocheckedaddresses ( fcpo_address_hash ) VALUES ( '{$sCheckHash}' )";
+        $sQuery = "REPLACE INTO fcpocheckedaddresses ( fcpo_address_hash, fcpo_checkdate ) VALUES ( '{$sCheckHash}', NOW() )";
         oxDb::getDb()->Execute($sQuery);
     }
 


### PR DESCRIPTION
Table fcpocheckedaddresses has two TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP.
This works fine with MYSQL 5.7 but MySQL 5.5 bitterly complains. The OXTIMESTAMP column
is standard for all tables in OXID eShop to track the date of last change and if I remember correctly,
there’s some test if all tables have the OXTIMESTAMP column.
What PayOne module uses is the fcpocheckedaddresses.fcpo_checkdate. 
fcpocheckedaddresses.fcpo_checkdate should also be updated to current timestamp on each
write access to that row. In the long term, oxtimestamp could be used and fcpocheckedaddresses.fcpo_checkdate
could be dropped.
But as we need a fix for 1.4 which works with MySQL 5.5 and 5.7, the easiest fix seems to be to give
fcpocheckedaddresses.fcpo_checkdate a dummy default (to prevent NON_ZERO_DATE issues with MySQL 5.7)
and on insert/replace update this to current timestamp as done in this PR.