### PR TITLE
Fix: fatal errors with PHP 8

### DIFF
--- a/tests/unit/fcPayOne/application/models/fcpoerrormappingTest.php
+++ b/tests/unit/fcPayOne/application/models/fcpoerrormappingTest.php
@@ -135,10 +135,10 @@ class Unit_fcPayOne_Application_Models_fcpoerrormapping extends OxidTestCase
 
     /**
      * Testing fcpoGetAvailableErrorCodes throwing exception
-     * @expectedException oxException
      */
     public function test_fcpoGetAvailableErrorCodes_Exception() 
     {
+        $this->expectException(oxException::class);
         $oMockException = new oxException('someErrorMessage');
         $oTestObject = $this->getMock('fcpoerrormapping', array('_fcpoParseXml'));
         $oTestObject->expects($this->any())->method('_fcpoParseXml')->will($this->throwException($oMockException));

--- a/tests/unit/fcPayOne/application/models/fcpoexportconfigTest.php
+++ b/tests/unit/fcPayOne/application/models/fcpoexportconfigTest.php
@@ -341,7 +341,7 @@ class Unit_fcPayOne_Application_Models_fcpoexportconfig extends OxidTestCase
         //        $this->assertEquals($aExpect, $aResponse);
         $this->_fcpoTruncateTable('fcpostatusmapping');
 
-        $this->assertContains('<title><![CDATA[AmazonPay]]></title>', $aResponse);
+        $this->assertStringContainsString('<title><![CDATA[AmazonPay]]></title>', $aResponse);
     }
 
     /**


### PR DESCRIPTION
With the upcoming OXID 6.3.0 we added PHP 8 support and found the below errors while testing. The PR fixes only the fatal errors.

```
1. Unit_fcPayOne_Application_Models_fcpoerrormapping::test_fcpoGetAvailableErrorCodes_Exception

The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

/var/www/oxideshop/vendor/oxid-esales/testing-library/library/UnitTestCase.php:150

2. Unit_fcPayOne_Application_Models_fcpoexportconfig::test__fcpoGetShopXmlClearingTypes_Coverage

Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.

/var/www/oxideshop/vendor/oxid-esales/testing-library/library/UnitTestCase.php:150
```