### PR TITLE
OX6-105 : General fix

### DIFF
--- a/application/models/fcpayone_ajax.php
+++ b/application/models/fcpayone_ajax.php
@@ -646,9 +646,12 @@ class fcpayone_ajax extends oxBase
         ];
 
         $aSupportedNetwork = [];
-        foreach ($oConfig->getConfigParam('aFCPOAplCreditCards') as $sCardCode) {
-            if (isset($aCreditCardMapping[$sCardCode])) {
-                $aSupportedNetwork[] = $aCreditCardMapping[$sCardCode];
+        $aConfigAplCreditCard = $oConfig->getConfigParam('aFCPOAplCreditCards');
+        if (!empty($aConfigAplCreditCard)) {
+            foreach ($oConfig->getConfigParam('aFCPOAplCreditCards') as $sCardCode) {
+                if (isset($aCreditCardMapping[$sCardCode])) {
+                    $aSupportedNetwork[] = $aCreditCardMapping[$sCardCode];
+                }
             }
         }
 

--- a/lib/fcporequest.php
+++ b/lib/fcporequest.php
@@ -1435,7 +1435,8 @@ class fcpoRequest extends oxSuperCfg
             $iIndex++;
         }
         // discounts
-        foreach ($oBasket->getDiscounts() AS $oDiscount) {
+        $aDiscounts = is_null($oBasket->getDiscounts()) ? [] : $oBasket->getDiscounts();
+        foreach ($aDiscounts AS $oDiscount) {
             $this->addParameter('it[' . $iIndex . ']', 'voucher');
             $this->addParameter('id[' . $iIndex . ']', 'discount');
             $this->addParameter('pr[' . $iIndex . ']', $this->_fcpoGetCentPrice($oDiscount->dDiscount * -1));

--- a/out/blocks/fcpo_order_override.tpl
+++ b/out/blocks/fcpo_order_override.tpl
@@ -49,6 +49,6 @@
     <script src="https://x.klarnacdn.net/kp/lib/v1/api.js" async></script>
     [{/if}]
 [{else}]
-    [{assign var="sFcPoTemplatePath" value=$sFcPoTemplatePath|cat:'/fcpo_nosalutation_order.tpl'}]
+    [{assign var="sFcPoTemplatePath" value=$oViewConf->fcpoGetActiveThemePath()|cat:'/fcpo_nosalutation_order.tpl'}]
     [{include file=$oViewConf->fcpoGetAbsModuleTemplateFrontendPath($sFcPoTemplatePath)}]
 [{/if}]


### PR DESCRIPTION
 - Apple Pay : safety check to prevent method specific code execution when not applicable
 - PO Request : safety check to prevent errors related to discount configuration
 - Checkout review : fix template path generation failing for amazonpay checkout