### PR TITLE
Fix forwarding timeouts

### DIFF
--- a/status.php
+++ b/status.php
@@ -262,7 +262,7 @@ class fcPayOneTransactionStatusHandler extends fcPayOneTransactionStatusBase
         $sShopUrl = $oConfig->getShopUrl();
         $sSslShopUrl = $oConfig->getSslShopUrl();
         $sConfTimeout = $oConfig->getConfigParam('sTransactionRedirectTimeout');
-        $iTimeout = ($sConfTimeout) ? (int) $sConfTimeout : 5500;
+        $iTimeout = ($sConfTimeout) ? (int) $sConfTimeout : 10;
         $sParams = substr($sParams,1);
         $sBaseUrl = (empty($sSslShopUrl)) ? $sShopUrl : $sSslShopUrl;
 
@@ -277,7 +277,7 @@ class fcPayOneTransactionStatusHandler extends fcPayOneTransactionStatusBase
         curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, false);
 
         curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($oCurl, CURLOPT_TIMEOUT_MS, $iTimeout);
+        curl_setopt($oCurl, CURLOPT_TIMEOUT, $iTimeout);
 
         curl_exec($oCurl);
         $aResult = curl_getinfo($oCurl);

--- a/statusforward.php
+++ b/statusforward.php
@@ -275,13 +275,11 @@ class fcPayOneTransactionStatusForwarder extends fcPayOneTransactionStatusBase {
      */
     protected function _forwardRequest($sQueueId, $sForwardId, $sStatusmessageId) {
         try {
-            $oConfig = $this->getConfig();
-            $sConfTimeout = $oConfig->getConfigParam('sTransactionRedirectTimeout');
-            $iTimeout = ($sConfTimeout) ? (int) $sConfTimeout : 10;
             $aParams = $this->_fetchPostParams($sStatusmessageId);
             $sParams = $aParams['string'];
             $aRequest = $aParams['array'];
             $aForwardData = $this->_getForwardData($sForwardId);
+            $iTimeout = $aForwardData['timeout'] ? (int) $aForwardData['timeout'] : 10;
 
             $sUrl = $aForwardData['url'];
             $this->_logForwardMessage('Trying to forward to url: '.$sUrl.'...');


### PR DESCRIPTION
Fixes for the timeouts used for the transaction status forwarding:
- the timeout for the internal redirect should be set in seconds as per the documentation
- for the actual forwarding, the timeout from the forward setting should be used