### PR TITLE
Fixes for admin list views

### DIFF
--- a/application/controllers/admin/fcpayone_apilog_list.php
+++ b/application/controllers/admin/fcpayone_apilog_list.php
@@ -30,11 +30,18 @@ class fcpayone_apilog_list extends fcpayone_adminlist
     protected $_sListClass = 'fcporequestlog';
 
     /**
-     * Default SQL sorting parameter (default null).
+     * Default sorting field
      *
      * @var string
      */
-    protected $_sDefSort = "fcporequestlog.oxtimestamp desc";
+    protected $_sDefSortField = 'oxtimestamp';
+
+    /**
+     * Enable/disable sorting by DESC (SQL) (default false - disable).
+     *
+     * @var bool
+     */
+    protected $_blDesc = true;
 
     /**
      * Current class template name

--- a/application/controllers/admin/fcpayone_log_list.php
+++ b/application/controllers/admin/fcpayone_log_list.php
@@ -31,11 +31,18 @@ class fcpayone_log_list extends fcpayone_adminlist
     protected $_sListClass = 'fcpotransactionstatus';
 
     /**
-     * Default SQL sorting parameter (default null).
+     * Default sorting field
      *
      * @var string
      */
-    protected $_sDefSort = "fcpotransactionstatus.oxtimestamp desc";
+    protected $_sDefSortField = 'oxtimestamp';
+
+    /**
+     * Enable/disable sorting by DESC (SQL) (default false - disable).
+     *
+     * @var bool
+     */
+    protected $_blDesc = true;
 
     /**
      * Current class template name

--- a/application/views/admin/tpl/fcpayone_apilog_main.tpl
+++ b/application/views/admin/tpl/fcpayone_apilog_main.tpl
@@ -7,7 +7,7 @@
 
 <!-- frames -->
 <frameset  rows="40%,*" border="0">
-    <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $listurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="list" marginwidth="0" marginheight="0" scrolling="off" frameborder="0">
+    <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $listurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="list" marginwidth="0" marginheight="0" scrolling="auto" frameborder="0">
     <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $editurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="edit" marginwidth="0" marginheight="0" scrolling="auto" frameborder="0">
 </frameset>
 

--- a/application/views/admin/tpl/fcpayone_protocol.tpl
+++ b/application/views/admin/tpl/fcpayone_protocol.tpl
@@ -7,7 +7,7 @@
 
 <!-- frames -->
 <frameset  rows="40%,*" border="0">
-    <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $listurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="list" marginwidth="0" marginheight="0" scrolling="off" frameborder="0">
+    <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $listurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="list" marginwidth="0" marginheight="0" scrolling="auto" frameborder="0">
     <frame src="[{$oViewConf->getSelfLink()}][{$oView->fcGetAdminSeperator()}][{ $editurl }][{ if $oxid }]&oxid=[{$oxid}][{/if}]" name="edit" marginwidth="0" marginheight="0" scrolling="auto" frameborder="0">
 </frameset>
 


### PR DESCRIPTION
Fixes for the admin list views of API requests / transactions
- fixed the default sorting
- allow scrolling to make the pagination always accessible (might be hidden when lines contain long text which is wrapped)